### PR TITLE
Bugfix: added default value of "None" to collection_id parameter for verification link generation

### DIFF
--- a/app/helpers.py
+++ b/app/helpers.py
@@ -589,10 +589,11 @@ def check_user_in_auth_viewers(user, item, item_type) -> bool:
         viewers = single_query_template_collection({"_id": item}).get("auth_viewers")
         viewers = viewers[0]
 
-    for i in viewers:
-        for k, v in i.items():
-            if k != "portfolio":
-                auth_viewers.append(v)
+    if viewers:
+        for i in viewers:
+            for k, v in i.items():
+                if k != "portfolio":
+                    auth_viewers.append(v)
 
     if user in auth_viewers:
         return True

--- a/app/mongo_db_connection.py
+++ b/app/mongo_db_connection.py
@@ -741,7 +741,7 @@ def update_folder(folder_id, old_folder):
 
 
 def authorize_metadata(metadata_id, viewers, process_id, item_type):
-    print(metadata_id, viewers, process_id, item_type)
+    print("authorize_metadata: ", metadata_id, viewers, process_id, item_type)
     payload = None
     if item_type == "document": # document here is process_type
         payload = json.dumps(
@@ -817,21 +817,21 @@ def authorize(document_id, viewers, process_id, item_type):
             }
         )
             
-        metadata_payload = json.dumps(
-            {
-                **CLONES_METADATA_CONNECTION_DICT,
-                "command": "update",
-                "field": {
-                    "collection_id": document_id,
-                },
-                "update_field": {
-                    "auth_viewers": [viewers],
-                    "document_state": "processing",
-                    "process_id": process_id,
-                },
-                "platform": "bangalore",
-            }
-        )
+    metadata_payload = json.dumps(
+        {
+            **CLONES_METADATA_CONNECTION_DICT,
+            "command": "update",
+            "field": {
+                "collection_id": document_id,
+            },
+            "update_field": {
+                "auth_viewers": [viewers],
+                "document_state": "processing",
+                "process_id": process_id,
+            },
+            "platform": "bangalore",
+        }
+    )
 
     if payload is not None:
         meta_payload = post_to_data_service(metadata_payload)

--- a/app/processing.py
+++ b/app/processing.py
@@ -508,7 +508,7 @@ class HandleProcess:
                 return editor_link
     
     # Verify_Access V2
-    def verify_access_v2(self, auth_role, user_name, user_type, document_id):
+    def verify_access_v2(self, auth_role, user_name, user_type, collection_id=None):
         clone_id = None
         doc_map = None
         right = None
@@ -526,9 +526,12 @@ class HandleProcess:
                 if any(user_name in map for map in step.get("stepDocumentCloneMap")):
                     for d_map in step["stepDocumentCloneMap"]:
                         if d_map.get(user_name) is not None:
-                            if d_map.get(user_name) == document_id:
+                            # Check if the collection_id is passed as an argument
+                            if collection_id is not None:
+                                if d_map.get(user_name) == collection_id:
+                                    clone_id = d_map.get(user_name)
+                            else:
                                 clone_id = d_map.get(user_name)
-                            # clone_id = d_map.get(user_name)
                     doc_map = step["stepDocumentMap"]
                     right = step["stepRights"]
                     role = step["stepRole"]
@@ -625,6 +628,7 @@ class Background:
                         current_doc_map = [v for document_map in step["stepDocumentCloneMap"] for k, v in document_map.items() if isinstance(v, str)]
                         user_in_viewers = check_user_in_auth_viewers(user=self.username, item=document_id, item_type="document")
                         if (not user_in_viewers):
+                            print("user not in auth_viewers: ", user_in_viewers)
                             pass
                         elif document_id in current_doc_map:
                             for document_map in step.get("stepDocumentCloneMap"):
@@ -709,7 +713,7 @@ class Background:
                                                 )
                                                 # Change auth viewers in the metadata as well
                                                 metadata_id = get_metadata_id(
-                                                    document, "document"
+                                                    document, "clone"
                                                 )
                                                 authorize_metadata(
                                                     metadata_id, user, process_id, "document"
@@ -726,7 +730,7 @@ class Background:
                                                 )
                                                 # Change auth viewers in the metadata as well
                                                 metadata_id = get_metadata_id(
-                                                    document, "document"
+                                                    document, "clone"
                                                 )
                                                 authorize_metadata(
                                                     metadata_id, user, process_id, "document"
@@ -743,7 +747,7 @@ class Background:
                                                 )
                                                 # Change auth viewers in the metadata as well
                                                 metadata_id = get_metadata_id(
-                                                    document, "document"
+                                                    document, "clone"
                                                 )
                                                 authorize_metadata(
                                                     metadata_id, user, process_id, "document"
@@ -792,7 +796,7 @@ class Background:
                                         )
                                         # Change auth viewers in the metadata as well
                                         metadata_id = get_metadata_id(
-                                            document, "document"
+                                            document, "clone"
                                         )
                                         authorize_metadata(
                                             metadata_id, user, process_id, "document"
@@ -806,7 +810,7 @@ class Background:
                                         )
                                         # Change auth viewers in the metadata as well
                                         metadata_id = get_metadata_id(
-                                            document, "document"
+                                            document, "clone"
                                         )
                                         authorize_metadata(
                                             metadata_id, user, process_id, "document"
@@ -820,7 +824,7 @@ class Background:
                                         )
                                         # Change auth viewers in the metadata as well
                                         metadata_id = get_metadata_id(
-                                            document, "document"
+                                            document, "clone"
                                         )
                                         authorize_metadata(
                                             metadata_id, user, process_id, "document"

--- a/app/views.py
+++ b/app/views.py
@@ -299,7 +299,7 @@ def process_verification_v2(request):
     # collection_id = request.data["collection_id"]
     link_object = single_query_qrcode_collection({"unique_hash": token})
     if user_type == "team" or user_type == "user":
-        collection_id = request.data["collection_id"]
+        collection_id = request.data["collection_id"] if request.data.get("collection_id") else None
         if (
             link_object["user_name"] != auth_user
             or link_object["auth_portfolio"] != auth_portfolio


### PR DESCRIPTION
You can now open verification links (for Team and User members) without having to pass the collection_id.

NB: This may cause unexpected behaviour. Hence, for optimal performance, it is advised to pass the collection_id (of the document you are trying to access) in the payload.