### PR TITLE
Update: Changed the way data is being passed || Update the workflow details for step with internal workflow permitted

### DIFF
--- a/app/processing.py
+++ b/app/processing.py
@@ -835,7 +835,7 @@ class Background:
                         if (not user_in_viewers):
                             continue
                         elif document_id in current_doc_map:
-                            if step.get("permitInternalWorkflow") == True:
+                            if step.get("permitInternalWorkflow") == True and step.get("workflows") != None:
                                 if step.get("internal_process_details") == None:
                                     internal_process_workflows = step.get("workflows")
 

--- a/app/views_v2.py
+++ b/app/views_v2.py
@@ -288,6 +288,33 @@ class ProcessDetail(APIView):
                 process.update({"links": links_object["links"]})
         process["progress"] = progress
         return Response(process, status.HTTP_200_OK)
+    
+    
+    def put(self, request, process_id):
+        """_summary_
+        Args:
+            request (req): _description_
+            process_id (str): _description_
+        """
+        if not validate_id(process_id):
+            return Response("Something went wrong!", status.HTTP_400_BAD_REQUEST)
+        
+        if not request.query_params.get("step_id"):
+            return Response("Invalid request: step_id is missing", status.HTTP_400_BAD_REQUEST)
+        step_id = int(request.query_params.get("step_id"))
+        step_id -= 1
+        
+        process = single_query_process_collection({"_id": process_id})
+        steps = process.get("process_steps")
+        state = "processing_state"
+        
+        step_content = steps[step_id]
+        if step_content.get("permitInternalWorkflow") == True:
+            step_content.update({"workflows": "Testing 234"})
+            update_process(process_id, steps, state)
+            return Response(process, status.HTTP_200_OK)
+        else:
+            return Response("Internal workflow is not permitted in this step", status.HTTP_403_FORBIDDEN)
 
 
 class ProcessLink(APIView):

--- a/app/views_v2.py
+++ b/app/views_v2.py
@@ -299,9 +299,11 @@ class ProcessDetail(APIView):
         if not validate_id(process_id):
             return Response("Something went wrong!", status.HTTP_400_BAD_REQUEST)
         
-        if not request.query_params.get("step_id"):
-            return Response("Invalid request: step_id is missing", status.HTTP_400_BAD_REQUEST)
-        step_id = int(request.query_params.get("step_id"))
+        if not request.data:
+            return Response("Some parameters are missing", status.HTTP_400_BAD_REQUEST)
+        
+        workflow = request.data.get("workflows")
+        step_id = request.data.get("step_id")
         step_id -= 1
         
         process = single_query_process_collection({"_id": process_id})
@@ -310,7 +312,7 @@ class ProcessDetail(APIView):
         
         step_content = steps[step_id]
         if step_content.get("permitInternalWorkflow") == True:
-            step_content.update({"workflows": "Testing 234"})
+            step_content.update({"workflows": workflow})
             update_process(process_id, steps, state)
             return Response(process, status.HTTP_200_OK)
         else:


### PR DESCRIPTION
The workflow can now be injected directly from the process details page, after which the document can be opened and finalized, for the internal process to get created.