### PR TITLE
Update: Previous and next step member info on process verification

### DIFF
--- a/app/helpers.py
+++ b/app/helpers.py
@@ -655,10 +655,10 @@ def create_document_helper(
     """_summary_
 
     Args:
-        created_by (_type_): _description_
-        portfolio (_type_): _description_
-        company_id (_type_): _description_
-        template_id (_type_): _description_
+        created_by (str): _description_
+        portfolio (str): _description_
+        company_id (str): _description_
+        template_id (str): _description_
     """
     try:
         content = single_query_template_collection({"_id": template_id})["content"]

--- a/app/helpers.py
+++ b/app/helpers.py
@@ -702,3 +702,50 @@ def create_document_helper(
     except Exception as ex:
         print(ex)
         return
+
+
+def get_prev_and_next_users(process: dict, auth_user: str, auth_role: str, user_type: str) -> tuple:
+    """ Gets the previous step signers and potential next step signers
+        for specific process step
+
+    Args:
+        process (dict): A process dictionary
+        auth_user (str):  Username of the user in question
+        auth_role (str):  Role of the user in question
+        
+    Returns:
+        tuple: (previous, next)
+    """
+    process_steps = process["process_steps"]
+    prev_step = None
+    next_step = None
+    prev_viewers = None
+    next_viewers = None
+    
+    if user_type == "public":
+        auth_user = auth_user[0]
+    else:
+        auth_user = auth_user
+    
+    for current_idx, step in enumerate(process["process_steps"]):
+        if step.get("stepRole") == auth_role:
+            for item in step["stepDocumentCloneMap"]:
+                if item.get(auth_user):
+                    current_doc_id = item.get(auth_user)
+                    # Check previous step get it's users
+                    if current_idx > 0:
+                        prev_step = process["process_steps"][current_idx - 1]
+                        prev_viewers_doc_map = prev_step["stepDocumentCloneMap"]
+                        prev_viewers = [k for item in prev_viewers_doc_map for k, v in item.items() if v == current_doc_id]
+                                                
+                    if current_idx < len(process_steps) - 1:
+                        next_step = process["process_steps"][current_idx + 1]
+                        next_viewers_team_doc_map = next_step["stepTeamMembers"]
+                        next_viewers_user_doc_map = next_step["stepUserMembers"]
+                        next_viewers_public_doc_map = next_step["stepPublicMembers"]
+                        next_viewers = [item.get("member") for doc_map in [next_viewers_team_doc_map, next_viewers_user_doc_map, next_viewers_public_doc_map] for item in doc_map]
+                        
+                        
+    return (prev_viewers, next_viewers)
+                            
+    

--- a/app/processing.py
+++ b/app/processing.py
@@ -572,7 +572,7 @@ class HandleProcess:
                 return editor_link
     
     # Verify_Access V2
-    def verify_access_v2(self, auth_role, user_name, user_type, collection_id=None):
+    def verify_access_v2(self, auth_role, user_name, user_type, collection_id=None, prev_viewers=None, next_viewers=None):
         clone_id = None
         doc_map = None
         right = None
@@ -644,6 +644,8 @@ class HandleProcess:
                         "document_right": right,
                         "document_flag": item_flag,
                         "role": role,
+                        "previous_viewers": prev_viewers,
+                        "next_viewers": next_viewers,
                         "metadata_id": metadata_id,
                         "process_id": self.process["_id"],
                         "update_field": {

--- a/app/views_v2.py
+++ b/app/views_v2.py
@@ -417,15 +417,11 @@ class ProcessVerification(APIView):
             )
 
         editor_link = handler.verify_access_v2(
-            auth_role, auth_user, user_type, collection_id
+            auth_role, auth_user, user_type, collection_id, prev_viewers, next_viewers
         )
         if editor_link:
             return Response(
-                {
-                    "link": editor_link,
-                    "previous": prev_viewers,
-                    "next":next_viewers
-                }, 
+                editor_link, 
                 status.HTTP_200_OK)
         else:
             return Response(


### PR DESCRIPTION
I have added the required details to the process verification endpoint. Before this gets merged, the frontend team need to be notified of these changes:

Hitting the /verify endpoint will no longer return just the editor link as a string. The new response object is as follows:

```
{
    "link": "<string: editor link>",
    "previous": ["<string: username1>", "<string: username2>", ...] || null,
    "next": ["<string: username1>", "<string: username2>", ...] || null
}